### PR TITLE
Add configuration for install dirs to INSTALL, and respect XDG directories.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
-   
+
+## CONFIGURATION
+
+PREFIX=/usr/local/bin         # Directory in which to install the binary
+MANPREFIX=/usr/share/man/man1 # Directory in which to install the manual page
+
+## CODE
+
+XDG_PICTURES_DIR=${XDG_PICTURES_DIR:-$HOME/Pictures}
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
+
 if [[ $1 == "clone" ]]; then
-    [[ ! -e /usr/local/bin/moe ]] && sudo cp ./moe /usr/local/bin/moe
-    [[ ! -e /usr/share/man/man1/moe ]] && sudo cp ./moe.1.gz /usr/share/man/man1/moe
-    [[ ! -e $HOME/.config/moe ]] && mkdir $HOME/.config/moe
-    [[ ! -e $HOME/Pictures/moe ]] && mkdir $HOME/Pictures/moe
+    [[ ! -e $PREFIX/moe ]] && sudo cp ./moe $PREFIX/moe
+    [[ ! -e $MANPREFIX/moe ]] && sudo cp ./moe.1.gz $MANPREFIX/moe
+    [[ ! -e $XDG_CONFIG_HOME/moe ]] && mkdir $XDG_CONFIG_HOME/moe
+    [[ ! -e $XDG_PICTURES_DIR/moe ]] && mkdir $XDG_PICTURES_DIR/moe
 fi
 
 if [[ $1 == "update" ]]; then
-    sudo cp ./moe /usr/local/bin/moe
-    sudo cp ./moe.1.gz /usr/share/man/man1/moe
+    sudo cp ./moe $PREFIX/moe
+    sudo cp ./moe.1.gz $MANPREFIX/moe
 fi
  


### PR DESCRIPTION
There are also fallbacks if needed. Yes, I know this can be customized in moerc, but some users (e.g. me) would prefer for a Pictures directory to not be created, as my pictures directory is set to ~/usr/pictures.
